### PR TITLE
Fix: Prevent RuntimeError for hass is None in sensor setup

Resolves a `RuntimeError: Attribute hass is None for <entity unknown.unknown=unknown>`
that occurred during the setup of the sensor platform.

The error was caused by calling `_handle_coordinator_update()` (which
calls `async_write_ha_state()`) from the `FlashforgeSensor.__init__`
method, at which point `self.hass` is not yet assigned to the entity.

The call to `self._handle_coordinator_update()` has been removed from
`__init__`. The existing `async_added_to_hass` method already handles
the initial state update correctly after `self.hass` is available.

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -124,8 +124,6 @@ class FlashforgeSensor(CoordinatorEntity, SensorEntity):
             "sw_version": fw,
         }
 
-        self._handle_coordinator_update()
-
     def _handle_coordinator_update(self) -> None:
         self._attr_available = self.coordinator.last_update_success
         raw_value = None


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

