### PR TITLE
Feat: Add new sensors based on extended API data

Adds 13 new sensor definitions to `SENSOR_DEFINITIONS` in `sensor.py`
based on a fuller API response you provided. This expands the
range of information available from the Flashforge Adventurer 5M PRO
integration.

New sensors include:
- Auto Shutdown Status & Time
- Current Print Speed
- Flash Register Code & Polar Register Code
- Location, MAC Address, Build Volume
- Nozzle Count, Model, & Style
- Printer ID (PID)
- Print Speed Adjustment

Appropriate names, units, device classes, and state classes have been
assigned based on the nature of the data and Home Assistant conventions.
The existing 6-tuple structure for sensor definitions has been maintained.

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -56,6 +56,19 @@ SENSOR_DEFINITIONS = {
     "remainingDiskSpace": ("Remaining Disk Space", UnitOfInformation.GIGABYTES, SensorDeviceClass.DATA_SIZE, SensorStateClass.MEASUREMENT, False, False),
     "zAxisCompensation": ("Z Axis Compensation", UnitOfLength.MILLIMETERS, None, SensorStateClass.MEASUREMENT, False, False),
     # Add more as needed...
+    "autoShutdown": ("Auto Shutdown Status", None, None, None, False, False),
+    "autoShutdownTime": ("Auto Shutdown Time", UnitOfTime.MINUTES, SensorDeviceClass.DURATION, SensorStateClass.MEASUREMENT, False, False),
+    "currentPrintSpeed": ("Current Print Speed", "mm/s", SensorDeviceClass.SPEED, SensorStateClass.MEASUREMENT, False, False),
+    "flashRegisterCode": ("Flash Register Code", None, None, None, False, False),
+    "location": ("Location", None, None, None, False, False),
+    "macAddr": ("MAC Address", None, None, None, False, False),
+    "measure": ("Build Volume", None, None, None, False, False),
+    "nozzleCnt": ("Nozzle Count", None, None, SensorStateClass.MEASUREMENT, False, False),
+    "nozzleModel": ("Nozzle Model", None, None, None, False, False),
+    "nozzleStyle": ("Nozzle Style", None, None, SensorStateClass.MEASUREMENT, False, False),
+    "pid": ("Printer ID (PID)", None, None, None, False, False),
+    "polarRegisterCode": ("Polar Register Code", None, None, None, False, False),
+    "printSpeedAdjust": ("Print Speed Adjustment", PERCENTAGE, None, SensorStateClass.MEASUREMENT, False, True),
 }
 
 async def async_setup_entry(hass, entry, async_add_entities):


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

