### PR TITLE
Fix: Correct light sensor state by updating API value mapping

The "Light On" binary sensor was incorrectly reporting the light as off
when it was on. This was due to a mismatch between the expected API value
("ON") and the actual value reported by the printer ("open") for the
`lightStatus` field.

This commit updates the `LIGHT_ON` constant in `const.py` from "ON" to
"open" to align with the printer's API response. The `binary_sensor.py`
already uses this constant correctly, so no changes were needed there.
This should ensure the light sensor now accurately reflects the printer's
light state.

### DIFF
--- a/const.py
+++ b/const.py
@@ -43,7 +43,7 @@ DOOR_OPEN = "OPEN"
 DOOR_CLOSED = "CLOSED"
 
 # Light status
-LIGHT_ON = "ON"
+LIGHT_ON = "open"
 LIGHT_OFF = "OFF"
 
 # Connection states


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

