### PR TITLE
Feat: Implement light control via JSON RPC command

This commit refactors the light control mechanism based on research
from OrcaSlicer's communication with Flashforge printers.

Changes:
- Add `ENDPOINT_JSON_RPC = "/"` to `const.py` for the new command path.
- In `coordinator.py`:
  - Add `_sequence_id` for use in JSON command payloads.
  - Implement `_send_raw_json_command` to POST JSON payloads directly,
    without the serialNumber/checkCode wrapper used by other commands.
  - Modify `toggle_light` to construct the `ledctrl` JSON payload
    (including `command`, `led_node`, `sequence_id`, `led_mode`, and
    default timing parameters) and send it via `_send_raw_json_command`
    to the new `ENDPOINT_JSON_RPC`.

This replaces the previous attempt to control the light by sending a
simple string to the `/command` endpoint, which resulted in a 404 error.
The new method aligns with how OrcaSlicer controls lights via JSON commands
sent over HTTP to port 8898, likely to the root path.

### DIFF
--- a/const.py
+++ b/const.py
@@ -24,6 +24,7 @@ ENDPOINT_PAUSE = "/pause"
 ENDPOINT_START = "/start"
 ENDPOINT_CANCEL = "/cancel"
 ENDPOINT_COMMAND = "/command"
+ENDPOINT_JSON_RPC = "/"
 
 # Printer states
 STATE_IDLE = "IDLE"


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

