### PR TITLE
Fix: Correct light control command structure and endpoint

This commit revises the implementation for toggling the printer light
based on your feedback and detailed API examples.

Changes:
- Remove `ENDPOINT_JSON_RPC` from `const.py` as it was unnecessary.
  Commands will be sent to `ENDPOINT_DETAIL`.
- In `coordinator.py`:
  - Remove the `_send_raw_json_command` method.
  - The `toggle_light` method now constructs a payload containing
    the `{"system": {"command": "ledctrl", ...}}` block.
  - This payload is passed as `extra_payload` to the existing
    `_send_command` method, which correctly wraps it with
    `serialNumber` and `checkCode` and sends it to `ENDPOINT_DETAIL`.
  - `_sequence_id` is used for the `ledctrl` command.

This aligns the light control with the printer's apparent expectation
that commands are POSTed to `/detail` and include root-level
authentication details wrapping the specific command payload.

### DIFF
--- a/const.py
+++ b/const.py
@@ -24,7 +24,6 @@ ENDPOINT_PAUSE = "/pause"
 ENDPOINT_START = "/start"
 ENDPOINT_CANCEL = "/cancel"
 ENDPOINT_COMMAND = "/command"
-ENDPOINT_JSON_RPC = "/"
 
 # Printer states
 STATE_IDLE = "IDLE"


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

