### PR TITLE
Fix: Correct SyntaxError in flashforge_tcp.py class docstring

Resolves an IndentationError during integration setup, which was caused
by an underlying SyntaxError in `flashforge_tcp.py`.

An extraneous double quote at the end of the `FlashforgeTCPClient` class
docstring was removed. This parsing error likely caused the subsequent
IndentationError reported by Python.

The corrected class docstring ensures the file can be parsed and
imported correctly.

### DIFF
--- a/flashforge_tcp.py
+++ b/flashforge_tcp.py
@@ -9,7 +9,7 @@ DEFAULT_TCP_TIMEOUT = 5
 TCP_BUFFER_SIZE = 1024
 
 class FlashforgeTCPClient:
-    """Client for sending M-code commands to Flashforge printers via TCP.".""
+    """Client for sending M-code commands to Flashforge printers via TCP."""
 
     def __init__(self, host: str, port: int, timeout: float = DEFAULT_TCP_TIMEOUT):
         """


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

