### PR TITLE
Feat: Transition print controls (start, pause, cancel) to TCP M-codes

This commit refactors the `start_print`, `pause_print`, and
`cancel_print` functionalities to use M-code commands sent over a
TCP connection (port 8899), consistent with the `toggle_light` update
and information you provided on printer communication.

Changes:
- In `coordinator.py`:
  - `start_print` now sends `~M23 0:/user/<filename>\r\n` via TCP.
  - `pause_print` now sends `~M25\r\n` via TCP.
  - `cancel_print` now sends `~M26\r\n` via TCP.
  - These methods now utilize the `FlashforgeTCPClient`.
- In `const.py`:
  - `ENDPOINT_PAUSE`, `ENDPOINT_START`, and `ENDPOINT_CANCEL` have been
    commented out as these HTTP endpoints are no longer used for these
    actions.

This moves the core control functions away from potentially unsupported
HTTP endpoints to the TCP M-code interface, aiming for more reliable
printer operations.

### DIFF
--- a/const.py
+++ b/const.py
@@ -21,10 +21,10 @@ BACKOFF_FACTOR = 1.5
 
 # API endpoints
 ENDPOINT_DETAIL = "/detail"
-ENDPOINT_PAUSE = "/pause"
-ENDPOINT_START = "/start"
-ENDPOINT_CANCEL = "/cancel"
-ENDPOINT_COMMAND = "/command"
+# ENDPOINT_PAUSE = "/pause" # Removed, functionality moved to TCP M-code
+# ENDPOINT_START = "/start" # Removed, functionality moved to TCP M-code
+# ENDPOINT_CANCEL = "/cancel" # Removed, functionality moved to TCP M-code
+ENDPOINT_COMMAND = "/command" # Retained for potential other HTTP commands
 
 # Printer states
 STATE_IDLE = "IDLE"

--- a/coordinator.py
+++ b/coordinator.py
@@ -147,19 +147,68 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
         return None # Should not be reached if try/except is comprehensive
 
     async def pause_print(self):
-        """Pauses the current print using HTTP command."""
-        # Assuming /pause is a valid HTTP endpoint that uses the standard auth wrapper
-        return await self._send_command(ENDPOINT_PAUSE)
+        """Pauses the current print using TCP M-code ~M25."""
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = "~M25\r\n"
+        action = "PAUSE PRINT"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+        
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                # await self.async_request_refresh()
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
 
     async def start_print(self, file_path: str):
-        """Starts a new print using HTTP command with file_path."""
-        # Assuming /start is a valid HTTP endpoint that uses standard auth and takes file_path
-        return await self._send_command(ENDPOINT_START, extra_payload={"file_path": file_path})
+        """Starts a new print using TCP M-code ~M23."""
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = f"~M23 0:/user/{file_path}\r\n"
+        action = f"START PRINT ({file_path})"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+        
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                # Consider an immediate refresh if printer status changes instantly
+                # await self.async_request_refresh()
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
 
     async def cancel_print(self):
-        """Cancels the current print using HTTP command."""
-        # Assuming /cancel is a valid HTTP endpoint that uses the standard auth wrapper
-        return await self._send_command(ENDPOINT_CANCEL)
+        """Cancels the current print using TCP M-code ~M26."""
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = "~M26\r\n"
+        action = "CANCEL PRINT"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+        
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                # await self.async_request_refresh()
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
 
     async def toggle_light(self, on: bool):
         """Toggles the printer light ON or OFF using TCP M-code commands."""


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

