### PR TITLE
Here's a summary of the changes I've made:

I've added a new `resume_print` capability to the Flashforge Adventurer 5M PRO integration.

Specifically:
- In `coordinator.py`, I've added a method to send the `~M24\r\n` M-code command via TCP to port 8899, which will resume printing.
- In `__init__.py`, I've set up the system to call this new resume print method.
- In `services.yaml`, I've added a description for this new `resume_print` feature so you can easily understand what it does.

This new feature allows you to resume a paused print job.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -64,6 +64,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         state = call.data["state"]
         await coordinator.toggle_light(state)
 
+    async def handle_resume_print(call):
+        """Handle the service call to resume the print."""
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        await coordinator.resume_print()
+
     hass.services.async_register(DOMAIN, "pause_print", handle_pause_print)
     hass.services.async_register(DOMAIN, "start_print", handle_start_print, schema=vol.Schema({
         vol.Required("file_path"): cv.string,
@@ -72,6 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_register(DOMAIN, "toggle_light", handle_toggle_light, schema=vol.Schema({
         vol.Required("state"): cv.boolean,
     }))
+    hass.services.async_register(DOMAIN, "resume_print", handle_resume_print)
 
     return True
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -168,6 +168,28 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Exception during {action} TCP command: {e}")
             return False
 
+    async def resume_print(self):
+        """Resumes the current print using TCP M-code ~M24."""
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = "~M24\r\n"
+        action = "RESUME PRINT"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                # Consider an immediate refresh if printer status changes instantly
+                # await self.async_request_refresh()
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
+
     async def start_print(self, file_path: str):
         """Starts a new print using TCP M-code ~M23."""
         tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)

--- a/services.yaml
+++ b/services.yaml
@@ -44,3 +44,9 @@ toggle_light:
       example: true
       selector:
         boolean:
+
+resume_print:
+  name: Resume Print
+  description: >-
+    Resumes a previously paused print job on the Flashforge printer.
+  fields: {} # No fields are needed as it takes no arguments


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

