### PR TITLE
Feat: Add temperature and fan control services via TCP M-codes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -69,6 +69,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         await coordinator.resume_print()
 
+    async def handle_set_extruder_temperature(call):
+        """Handle the service call to set the extruder temperature."""
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        temperature = call.data.get("temperature")
+        if temperature is not None:
+            await coordinator.set_extruder_temperature(int(temperature))
+
+    async def handle_set_bed_temperature(call):
+        """Handle the service call to set the bed temperature."""
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        temperature = call.data.get("temperature")
+        if temperature is not None:
+            await coordinator.set_bed_temperature(int(temperature))
+
+    async def handle_set_fan_speed(call):
+        """Handle the service call to set the fan speed."""
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        speed = call.data.get("speed")
+        if speed is not None:
+            await coordinator.set_fan_speed(int(speed))
+
+    async def handle_turn_fan_off(call):
+        """Handle the service call to turn the fan off."""
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        await coordinator.turn_fan_off()
+
     hass.services.async_register(DOMAIN, "pause_print", handle_pause_print)
     hass.services.async_register(DOMAIN, "start_print", handle_start_print, schema=vol.Schema({
         vol.Required("file_path"): cv.string,
@@ -78,6 +104,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         vol.Required("state"): cv.boolean,
     }))
     hass.services.async_register(DOMAIN, "resume_print", handle_resume_print)
+    hass.services.async_register(
+        DOMAIN,
+        "set_extruder_temperature",
+        handle_set_extruder_temperature,
+        schema=vol.Schema({vol.Required("temperature"): cv.positive_int})
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "set_bed_temperature",
+        handle_set_bed_temperature,
+        schema=vol.Schema({vol.Required("temperature"): cv.positive_int})
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "set_fan_speed",
+        handle_set_fan_speed,
+        schema=vol.Schema({vol.Required("speed"): vol.All(vol.Coerce(int), vol.Range(min=0, max=255))})
+    )
+    hass.services.async_register(DOMAIN, "turn_fan_off", handle_turn_fan_off)
 
     return True
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -266,3 +266,95 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
             # This catches errors from tcp_client instantiation or if send_command itself raises an unexpected error
             _LOGGER.error(f"Exception during toggle_light TCP operation: {e}")
             return False
+
+    async def set_extruder_temperature(self, temperature: int):
+        """Sets the extruder temperature using TCP M-code ~M104."""
+        if not 0 <= temperature <= 300: # Example temperature range, adjust if known
+            _LOGGER.error(f"Invalid extruder temperature: {temperature}. Must be between 0 and 300.")
+            return False
+
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = f"~M104 S{temperature}\r\n"
+        action = f"SET EXTRUDER TEMPERATURE to {temperature}°C"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
+
+    async def set_bed_temperature(self, temperature: int):
+        """Sets the bed temperature using TCP M-code ~M140."""
+        if not 0 <= temperature <= 120: # Example temperature range, adjust if known
+            _LOGGER.error(f"Invalid bed temperature: {temperature}. Must be between 0 and 120.")
+            return False
+
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = f"~M140 S{temperature}\r\n"
+        action = f"SET BED TEMPERATURE to {temperature}°C"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
+
+    async def set_fan_speed(self, speed: int):
+        """Sets the fan speed using TCP M-code ~M106."""
+        if not 0 <= speed <= 255:
+            _LOGGER.error(f"Invalid fan speed: {speed}. Must be between 0 and 255.")
+            return False
+
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = f"~M106 S{speed}\r\n"
+        action = f"SET FAN SPEED to {speed}"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False
+
+    async def turn_fan_off(self):
+        """Turns the fan off using TCP M-code ~M107."""
+        tcp_client = FlashforgeTCPClient(self.host, DEFAULT_MCODE_PORT)
+        command = "~M107\r\n"
+        action = "TURN FAN OFF"
+
+        _LOGGER.info(f"Attempting to {action} using TCP command: {command.strip()}")
+
+        try:
+            success, response = await tcp_client.send_command(command)
+            if success:
+                _LOGGER.info(f"Successfully sent {action} command. Response: {response}")
+                return True
+            else:
+                _LOGGER.error(f"Failed to send {action} command. Response/Error: {response}")
+                return False
+        except Exception as e:
+            _LOGGER.error(f"Exception during {action} TCP command: {e}")
+            return False

--- a/services.yaml
+++ b/services.yaml
@@ -50,3 +50,59 @@ resume_print:
   description: >-
     Resumes a previously paused print job on the Flashforge printer.
   fields: {} # No fields are needed as it takes no arguments
+
+set_extruder_temperature:
+  name: Set Extruder Temperature
+  description: >-
+    Sets the target temperature for the printer's extruder.
+  fields:
+    temperature:
+      name: Temperature
+      description: Target temperature in Celsius.
+      required: true
+      example: 210
+      selector:
+        number:
+          min: 0
+          max: 300 # Adjust max based on printer capability if known, else a safe upper limit
+          mode: box # Or slider
+          unit_of_measurement: "°C"
+
+set_bed_temperature:
+  name: Set Bed Temperature
+  description: >-
+    Sets the target temperature for the printer's heated bed.
+  fields:
+    temperature:
+      name: Temperature
+      description: Target temperature in Celsius.
+      required: true
+      example: 60
+      selector:
+        number:
+          min: 0
+          max: 120 # Adjust max based on printer capability if known, else a safe upper limit
+          mode: box # Or slider
+          unit_of_measurement: "°C"
+
+set_fan_speed:
+  name: Set Fan Speed
+  description: >-
+    Sets the printer's cooling fan speed. Typically the part cooling fan.
+  fields:
+    speed:
+      name: Speed
+      description: Fan speed (0-255). 0 is off, 255 is full speed.
+      required: true
+      example: 128
+      selector:
+        number:
+          min: 0
+          max: 255
+          mode: slider # Slider is good for 0-255 range
+
+turn_fan_off:
+  name: Turn Fan Off
+  description: >-
+    Turns the printer's cooling fan off (equivalent to setting speed to 0 with M107).
+  fields: {} # No fields needed


### PR DESCRIPTION
This commit introduces services to control extruder and bed temperatures, and to manage fan speed for the Flashforge Adventurer 5M PRO integration. These controls are implemented using M-codes sent over the TCP interface (port 8899) via the `FlashforgeTCPClient`.

Changes:
- In `coordinator.py`:
  - Added `set_extruder_temperature(self, temperature: int)` (uses `~M104 S<temp>`).
  - Added `set_bed_temperature(self, temperature: int)` (uses `~M140 S<temp>`).
  - Added `set_fan_speed(self, speed: int)` (uses `~M106 S<speed>`).
  - Added `turn_fan_off(self)` (uses `~M107`).
- In `__init__.py`:
  - Defined and registered service handlers for:
    - `set_extruder_temperature` (takes `temperature`)
    - `set_bed_temperature` (takes `temperature`)
    - `set_fan_speed` (takes `speed`)
    - `turn_fan_off`
- In `services.yaml`:
  - Added definitions for the new services, including names, descriptions, and field details for arguments.

This significantly expands the printer control capabilities offered by the integration.

## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

