### PR TITLE
Refactor: Convert specific text sensors to binary sensors

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -31,7 +31,9 @@ from .const import (
     LIGHT_ON,
     CONNECTION_STATE_CONNECTED,
     ERROR_CODE_NONE,
-    UNIT_PROGRESS_PERCENT
+    UNIT_PROGRESS_PERCENT,
+    AUTO_SHUTDOWN_ENABLED_STATE, # Added
+    FAN_STATUS_ON_STATE          # Added
 )
 from .coordinator import FlashforgeDataUpdateCoordinator
 
@@ -101,6 +103,39 @@ async def async_setup_entry(
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
             error_sensor=True
+        ),
+
+        # Auto Shutdown Enabled
+        FlashforgeBinarySensor(
+            coordinator=coordinator,
+            name="Auto Shutdown Enabled",
+            icon="mdi:timer-cog-outline", # Or mdi:power-settings
+            device_class=None, # Or BinarySensorDeviceClass.POWER - using None for now
+            entity_category=EntityCategory.CONFIG, # It's a configurable setting
+            detail_attribute="autoShutdown",
+            value_on=AUTO_SHUTDOWN_ENABLED_STATE
+        ),
+
+        # External Fan Active
+        FlashforgeBinarySensor(
+            coordinator=coordinator,
+            name="External Fan Active",
+            icon="mdi:fan",
+            device_class=None, # Or BinarySensorDeviceClass.RUNNING - using None for now
+            entity_category=EntityCategory.DIAGNOSTIC,
+            detail_attribute="externalFanStatus",
+            value_on=FAN_STATUS_ON_STATE
+        ),
+
+        # Internal Fan Active
+        FlashforgeBinarySensor(
+            coordinator=coordinator,
+            name="Internal Fan Active",
+            icon="mdi:fan-alert", # Using a different fan icon for variety, or mdi:fan
+            device_class=None, # Or BinarySensorDeviceClass.RUNNING - using None for now
+            entity_category=EntityCategory.DIAGNOSTIC,
+            detail_attribute="internalFanStatus",
+            value_on=FAN_STATUS_ON_STATE
         )
     ]
     

--- a/const.py
+++ b/const.py
@@ -47,6 +47,10 @@ DOOR_CLOSED = "CLOSED"
 LIGHT_ON = "open"
 LIGHT_OFF = "OFF"
 
+# Binary sensor "on" states from API string values
+AUTO_SHUTDOWN_ENABLED_STATE = "open" # Based on API: autoShutdown: "open" / "close"
+FAN_STATUS_ON_STATE = "open"         # Based on API: externalFanStatus/internalFanStatus: "open" / "close"
+
 # Connection states
 CONNECTION_STATE_UNKNOWN = "unknown"
 CONNECTION_STATE_CONNECTED = "connected"

--- a/sensor.py
+++ b/sensor.py
@@ -50,13 +50,13 @@ SENSOR_DEFINITIONS = {
     "estimatedRightWeight": ("Estimated Right Weight", UnitOfMass.GRAMS, SensorDeviceClass.WEIGHT, SensorStateClass.MEASUREMENT, False, False),
     "chamberFanSpeed": ("Chamber Fan Speed", REVOLUTIONS_PER_MINUTE, None, SensorStateClass.MEASUREMENT, False, False),
     "coolingFanSpeed": ("Cooling Fan Speed", REVOLUTIONS_PER_MINUTE, None, SensorStateClass.MEASUREMENT, False, False),
-    "externalFanStatus": ("External Fan Status", None, None, None, False, False),
-    "internalFanStatus": ("Internal Fan Status", None, None, None, False, False),
+    # "externalFanStatus": ("External Fan Status", None, None, None, False, False), # Replaced by binary_sensor
+    # "internalFanStatus": ("Internal Fan Status", None, None, None, False, False), # Replaced by binary_sensor
     "tvoc": ("TVOC", "µg/m³", SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS, SensorStateClass.MEASUREMENT, False, False),
     "remainingDiskSpace": ("Remaining Disk Space", UnitOfInformation.GIGABYTES, SensorDeviceClass.DATA_SIZE, SensorStateClass.MEASUREMENT, False, False),
     "zAxisCompensation": ("Z Axis Compensation", UnitOfLength.MILLIMETERS, None, SensorStateClass.MEASUREMENT, False, False),
     # Add more as needed...
-    "autoShutdown": ("Auto Shutdown Status", None, None, None, False, False),
+    # "autoShutdown": ("Auto Shutdown Status", None, None, None, False, False), # Replaced by binary_sensor
     "autoShutdownTime": ("Auto Shutdown Time", UnitOfTime.MINUTES, SensorDeviceClass.DURATION, SensorStateClass.MEASUREMENT, False, False),
     "currentPrintSpeed": ("Current Print Speed", "mm/s", SensorDeviceClass.SPEED, SensorStateClass.MEASUREMENT, False, False),
     "flashRegisterCode": ("Flash Register Code", None, None, None, False, False),

--- a/translations/en.json
+++ b/translations/en.json
@@ -61,6 +61,15 @@
       },
       "error": {
         "name": "Error"
+      },
+      "auto_shutdown_enabled": {
+        "name": "Auto Shutdown Enabled"
+      },
+      "external_fan_active": {
+        "name": "External Fan Active"
+      },
+      "internal_fan_active": {
+        "name": "Internal Fan Active"
       }
     },
     "sensor": {
@@ -73,17 +82,8 @@
       "status": {
         "name": "Status"
       },
-      "auto_shutdown": {
-        "name": "Auto Shutdown"
-      },
       "auto_shutdown_time": {
         "name": "Auto Shutdown Time"
-      },
-      "door_status": {
-        "name": "Door Status"
-      },
-      "light_status": {
-        "name": "Light Status"
       },
       "ip_addr": {
         "name": "IP Address"


### PR DESCRIPTION
This commit refactors how "autoShutdown", "externalFanStatus", and "internalFanStatus" are represented, changing them from text-based sensors displaying "open"/"close" to more appropriate binary_sensors that report an on/off state.

Changes:
- In `sensor.py`:
  - Removed (commented out) the definitions for `autoShutdown`, `externalFanStatus`, and `internalFanStatus` from `SENSOR_DEFINITIONS`.
- In `const.py`:
  - Added `AUTO_SHUTDOWN_ENABLED_STATE = "open"`.
  - Added `FAN_STATUS_ON_STATE = "open"`. These constants map the API's string value for "on" states.
- In `binary_sensor.py`:
  - Added new `FlashforgeBinarySensor` entities:
    - "Auto Shutdown Enabled" (based on `autoShutdown` API field).
    - "External Fan Active" (based on `externalFanStatus` API field).
    - "Internal Fan Active" (based on `internalFanStatus` API field).
  - These use the new constants from `const.py` for their `value_on` logic.
- In `translations/en.json`:
  - Removed the old translations for these sensors under `entity.sensor`.
  - Added new translations for them under `entity.binary_sensor`.

This change improves your experience by providing clearer boolean states for these features in Home Assistant.

## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

