### PR TITLE
Refactor: Change entity_category for Auto Shutdown Enabled sensor

Changes `entity_category` from `EntityCategory.CONFIG` to `None`
for the "Auto Shutdown Enabled" binary sensor in `binary_sensor.py`.

This is a troubleshooting step to address an issue where this specific
sensor was reported as "unavailable" while other binary sensors,
defined similarly but with different or no entity categories,
were functioning correctly.

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -111,7 +111,7 @@ async def async_setup_entry(
             name="Auto Shutdown Enabled",
             icon="mdi:timer-cog-outline", # Or mdi:power-settings
             device_class=None, # Or BinarySensorDeviceClass.POWER - using None for now
-            entity_category=EntityCategory.CONFIG, # It's a configurable setting
+            entity_category=None, # Changed to None
             detail_attribute="autoShutdown",
             value_on=AUTO_SHUTDOWN_ENABLED_STATE
         ),


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

