### PR TITLE
Refactor: Change entity_category for fan activity binary sensors

I've changed `entity_category` from `EntityCategory.DIAGNOSTIC` to `None`
for the "External Fan Active" and "Internal Fan Active" binary
sensors in `binary_sensor.py`.

This change is based on your preference to have these sensors
displayed as primary entities for the device in Home Assistant,
rather than being grouped under the "Diagnostic" category.

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -122,7 +122,7 @@ async def async_setup_entry(
             name="External Fan Active",
             icon="mdi:fan",
             device_class=None, # Or BinarySensorDeviceClass.RUNNING - using None for now
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute="externalFanStatus",
             value_on=FAN_STATUS_ON_STATE
         ),
@@ -133,7 +133,7 @@ async def async_setup_entry(
             name="Internal Fan Active",
             icon="mdi:fan-alert", # Using a different fan icon for variety, or mdi:fan
             device_class=None, # Or BinarySensorDeviceClass.RUNNING - using None for now
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute="internalFanStatus",
             value_on=FAN_STATUS_ON_STATE
         )


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

