### PR TITLE
Feat: Add move_axis service for printer jogging control



### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -106,3 +106,47 @@ turn_fan_off:
   description: >-
     Turns the printer's cooling fan off (equivalent to setting speed to 0 with M107).
   fields: {} # No fields needed
+
+move_axis:
+  name: Move Axis
+  description: >-
+    Moves one or more printer axes to the specified coordinates at an optional feedrate.
+    Specify at least one axis (x, y, or z). All coordinates are absolute.
+  fields:
+    x:
+      name: X Coordinate
+      description: Target X-axis coordinate in mm.
+      optional: true
+      example: 100.0
+      selector:
+        number:
+          mode: box
+          step: 0.1 # Allow for fine control
+    y:
+      name: Y Coordinate
+      description: Target Y-axis coordinate in mm.
+      optional: true
+      example: 100.0
+      selector:
+        number:
+          mode: box
+          step: 0.1
+    z:
+      name: Z Coordinate
+      description: Target Z-axis coordinate in mm.
+      optional: true
+      example: 50.0
+      selector:
+        number:
+          mode: box
+          step: 0.1
+    feedrate:
+      name: Feedrate
+      description: Speed of movement in mm/minute. Printer's default if not specified.
+      optional: true
+      example: 3000
+      selector:
+        number:
+          min: 0 # Feedrate usually must be positive, coordinator may enforce
+          mode: box
+          unit_of_measurement: "mm/min"


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->This commit introduces a `move_axis` service to the Flashforge
Adventurer 5M PRO integration, allowing you to move the printer axes
to specified coordinates with an optional feedrate.

Changes include:
- In `coordinator.py`:
  - Added an `async def move_axis(self, x, y, z, feedrate)` method.
  - This method dynamically constructs the `~G0 X<x> Y<y> Z<z> F<feedrate>`
    M-code command based on provided (optional) arguments.
  - It uses the `FlashforgeTCPClient` to send the command via TCP
    to port 8899.
- In `__init__.py`:
  - Defined `handle_move_axis(call)` to extract optional parameters
    (x, y, z, feedrate) and call the coordinator's `move_axis` method.
  - Registered the `flashforge_adventurer5m.move_axis` service with
    a schema defining these optional fields.
- In `services.yaml`:
  - Added definition for the `move_axis` service, including
    user-friendly names, descriptions, and field details for x, y, z,
    and feedrate, utilizing number selectors for the UI.

This new service provides jogging capability for the printer via the
TCP M-code interface.

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

