### PR TITLE
Feat: Add sensor to list printable files from printer



### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -114,6 +114,9 @@
       },
       "error_code": {
         "name": "Error Code"
+      },
+      "printable_files": {
+        "name": "Printable Files Count"
       }
     }
   },


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->This commit introduces functionality to retrieve and display the list
of printable files stored on the Flashforge Adventurer 5M PRO printer.

Changes include:
- In `coordinator.py`:
  - Added a new method `_fetch_printable_files_list` that uses the
    `FlashforgeTCPClient` to send the `~M661\r\n` M-code command
    via TCP to port 8899.
  - Implemented parsing logic within this method to extract filenames
    from the printer's specific response format.
  - The main `_fetch_data` method now calls `_fetch_printable_files_list`
    and stores the retrieved file list in `coordinator.data['printable_files']`.
- In `sensor.py`:
  - Added a new sensor definition for "Printable Files Count".
  - This sensor's state displays the number of printable files.
  - The actual list of filenames is available as a 'files' attribute
    on this sensor.
  - Modified `FlashforgeSensor` to handle this special sensor type,
    initializing `_attr_extra_state_attributes` and populating the
    state and attribute correctly.
- In `translations/en.json`:
  - Added a user-friendly name "Printable Files Count" for the new
    sensor.

This feature allows you to see which files are available on your
printer directly within Home Assistant, which can be used as a basis
for selecting files to print.

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

