### PR TITLE
Fix: Update M661 file list parsing and add debug logging

Modifies the `_fetch_printable_files_list` method in `coordinator.py`:
- Changes the separator string used for splitting the M661 response.
  The new separator `"::\x00\x00\x00"` assumes that non-UTF-8 bytes
  (like `\xa3`) in the original binary separator are dropped by the
  `decode('utf-8', errors='ignore')` process in the TCP client.
- Adds more detailed debug logging statements to trace the parsing
  logic, including the number of parts after split and the
  intermediate states of extracted/cleaned file paths.

This aims to resolve an issue where parsing the `~M661` response
resulted in an empty file list and to improve diagnostics for any
potential remaining parsing issues.

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -158,9 +158,10 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
                 if response.startswith(prefix_to_remove):
                     payload_str = response[len(prefix_to_remove):]
 
-                # Separator for file entries, as identified from logs
-                separator = "::\xa3\xa3\x00\x00\x00"
+                # Separator for file entries, updated based on potential decode('utf-8', errors='ignore') behavior
+                separator = "::\x00\x00\x00"
                 parts = payload_str.split(separator)
+                _LOGGER.debug(f"Splitting M661 payload. Number of parts: {len(parts)}. First few parts if any: {parts[:5]}")
 
                 for part in parts:
                     # Paths are expected to start with "//data/"
@@ -168,8 +169,10 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
                     if path_start_index != -1:
                         # Extract from "//data/" to the end of this segment
                         file_path = part[path_start_index:]
+                        _LOGGER.debug(f"M661 parsing - Original part segment: '{part}', Found '//data/' at index {path_start_index}, Extracted file_path: '{file_path}'")
                         # Clean non-printable characters and trim whitespace
                         cleaned_path = "".join(filter(lambda x: x.isprintable(), file_path)).strip()
+                        _LOGGER.debug(f"M661 parsing - Cleaned path: '{cleaned_path}', Ends with .gcode/.gx: {cleaned_path.endswith(('.gcode', '.gx'))}")
                         # Ensure it's a gcode/gx file and not an empty string
                         if cleaned_path and cleaned_path.endswith((".gcode", ".gx")):
                             files_list.append(cleaned_path)


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

