### PR TITLE
Feat: Add X, Y, Z printer coordinate sensors



### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -70,6 +70,9 @@ SENSOR_DEFINITIONS = {
     "polarRegisterCode": ("Polar Register Code", None, None, None, False, False),
     "printSpeedAdjust": ("Print Speed Adjustment", PERCENTAGE, None, SensorStateClass.MEASUREMENT, False, True),
     "printable_files": ("Printable Files Count", "files", None, SensorStateClass.MEASUREMENT, True, False),
+    "x_position": ("X Position", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.MEASUREMENT, True, False),
+    "y_position": ("Y Position", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.MEASUREMENT, True, False),
+    "z_position": ("Z Position", UnitOfLength.MILLIMETERS, SensorDeviceClass.DISTANCE, SensorStateClass.MEASUREMENT, True, False),
 }
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/translations/en.json
+++ b/translations/en.json
@@ -117,6 +117,15 @@
       },
       "printable_files": {
         "name": "Printable Files Count"
+      },
+      "x_position": {
+        "name": "X Position"
+      },
+      "y_position": {
+        "name": "Y Position"
+      },
+      "z_position": {
+        "name": "Z Position"
       }
     }
   },


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->This commit introduces functionality to retrieve and display the current
X, Y, and Z coordinates of the Flashforge Adventurer 5M PRO printer.

Changes include:
- In `coordinator.py`:
  - Added a new method `_fetch_coordinates` that uses the
    `FlashforgeTCPClient` to send the `~M114\r\n` M-code command
    via TCP to port 8899.
  - Implemented regex-based parsing within this method to extract
    X, Y, and Z float values from the M114 response.
  - The main `_fetch_data` method now calls `_fetch_coordinates`
    (deferred on initial load for faster startup) and stores the
    retrieved coordinates in `coordinator.data` under `x_position`,
    `y_position`, and `z_position` keys.
- In `sensor.py`:
  - Added new sensor definitions to `SENSOR_DEFINITIONS` for
    "X Position", "Y Position", and "Z Position".
  - These sensors are configured with MILLIMETERS as the unit of
    measurement, SensorDeviceClass.DISTANCE, and
    SensorStateClass.MEASUREMENT.
- In `translations/en.json`:
  - Added user-friendly names "X Position", "Y Position", and
    "Z Position" for the new sensors.

This feature allows you to monitor the printer's current nozzle
position within Home Assistant.

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

