### PR TITLE
Fix: Correct comment syntax in coordinator.py

This commit fixes an unterminated string literal error within a
comment in the `_fetch_printable_files_list` method in `coordinator.py`.
A comment string was improperly broken over multiple lines, leading
to a SyntaxError during Python parsing.

The comment has been reformatted to be a valid single-line comment,
resolving the parsing error and allowing the integration to load correctly.

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -65,11 +65,8 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug(f"Raw response for {action}: {response}")
 
                 payload_str = response
-                # Remove known prefixes like "CMD M661 Received.
-ok
-"
-                # The client might have already stripped some part of it if "ok
-" was found early.
+                # Remove known prefixes like "CMD M661 Received.\r\nok\r\n"
+                # The client might have already stripped some part of it if "ok\r\n" was found early.
                 # A more robust way is to find where the actual data starts.
                 # The Wireshark log showed "D\xaa\xaaD\x00\x00\x00\x1b::\xa3\xa3\x00\x00\x00//data/..."
                 # and the first part of the logged payload was "DD\x00\x00\x00\x1b::\xa3\xa3\x00\x00\x00//data/..."


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

