### PR TITLE
Fix: Remove incorrect unit conversion for M114 coordinates

Modifies the `_fetch_coordinates` method in `coordinator.py` to use
the X, Y, and Z values parsed from the `~M114` M-code response directly,
without applying a `* 2.54` conversion factor.

This change is based on your feedback indicating that the previously
displayed millimeter values were too high. The new assumption is that
`~M114` reports coordinates directly in millimeters, and the previous
conversion (from presumed "tenths of an inch") was incorrect.

Sensors in `sensor.py` are already configured to display these values
as millimeters with `device_class: None`, so they should now display
the printer's reported millimeter values correctly.

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -120,7 +120,7 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
         command = "~M114\r\n"
         action = "FETCH COORDINATES"
         coordinates = {}
-        conversion_factor = 2.54 # Printer M114 reports in tenths-of-an-inch
+        # conversion_factor = 2.54 # Removed, assuming M114 reports in mm
 
         _LOGGER.debug(f"Attempting to {action} using TCP command: {command.strip()}")
 
@@ -134,14 +134,14 @@ class FlashforgeDataUpdateCoordinator(DataUpdateCoordinator):
                 match_z = re.search(r"Z:([+-]?\d+\.?\d*)", response)
 
                 if match_x:
-                    coordinates['x'] = float(match_x.group(1)) * conversion_factor
+                    coordinates['x'] = float(match_x.group(1))
                 if match_y:
-                    coordinates['y'] = float(match_y.group(1)) * conversion_factor
+                    coordinates['y'] = float(match_y.group(1))
                 if match_z:
-                    coordinates['z'] = float(match_z.group(1)) * conversion_factor
+                    coordinates['z'] = float(match_z.group(1))
 
                 if 'x' in coordinates and 'y' in coordinates and 'z' in coordinates:
-                    _LOGGER.debug(f"Successfully parsed and converted coordinates: {coordinates}")
+                    _LOGGER.debug(f"Successfully parsed coordinates: {coordinates}")
                     return coordinates
                 else:
                     _LOGGER.warning(f"Could not parse all X,Y,Z coordinates from M114 response: {response}. Parsed: {coordinates}")


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

