### PR TITLE
Add new sensors for Endstops and Bed Leveling Status



### DIFF
--- a/const.py
+++ b/const.py
@@ -90,4 +90,32 @@ MJPEG_DUMMY_URL = "http://0.0.0.0/"
 TCP_CMD_PRINT_FILE_PREFIX_USER = "0:/user/"
 TCP_CMD_PRINT_FILE_PREFIX_ROOT = "0:/"
 
+# Endstop Sensor Constants
+# These API_ATTR keys are placeholders for how we'll store parsed M119 output in coordinator.data
+API_ATTR_X_ENDSTOP_STATUS = "x_endstop_status"
+API_ATTR_Y_ENDSTOP_STATUS = "y_endstop_status"
+API_ATTR_Z_ENDSTOP_STATUS = "z_endstop_status"
+API_ATTR_FILAMENT_ENDSTOP_STATUS = "filament_endstop_status"
+
+# Endstop Sensor Names
+NAME_X_ENDSTOP = "X Endstop"
+NAME_Y_ENDSTOP = "Y Endstop"
+NAME_Z_ENDSTOP = "Z Endstop"
+NAME_FILAMENT_ENDSTOP = "Filament Sensor"
+
+# Endstop Sensor Icons
+ICON_X_ENDSTOP = "mdi:axis-x-arrow"
+ICON_Y_ENDSTOP = "mdi:axis-y-arrow"
+ICON_Z_ENDSTOP = "mdi:axis-z-arrow"
+ICON_FILAMENT_ENDSTOP = "mdi:filament"
+
+# Bed Leveling Sensor API Attribute Key
+API_ATTR_BED_LEVELING_STATUS = "bed_leveling_status"
+
+# Bed Leveling Sensor Name
+NAME_BED_LEVELING = "Bed Leveling Active"
+
+# Bed Leveling Sensor Icon
+ICON_BED_LEVELING = "mdi:checkerboard" # Or mdi:format-list-bulleted-type
+
 # Units


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->This commit introduces new binary sensors to provide enhanced diagnostic data from the Flashforge Adventurer 5M Pro, based on M-code commands.

**New Features:**

1.  **Endstop Status Sensors (`~M119`):**
    *   Added binary sensors for X, Y, Z, and Filament endstops.
    *   The `coordinator.py` now periodically sends `~M119` via TCP.
    *   The response is parsed to determine if each endstop is "triggered" or "open".
    *   These states are exposed as individual binary sensors in Home Assistant.
    *   Relevant constants for names, icons, and API attribute keys were added to `const.py`.
    *   The `FlashforgeBinarySensor` in `binary_sensor.py` was updated to correctly source data for these new top-level attributes in the coordinator's data.

2.  **Bed Leveling Status Sensor (`~M420`):**
    *   Added a binary sensor "Bed Leveling Active".
    *   The `coordinator.py` now sends `~M420 S0` (or a similar query) to determine if bed leveling compensation is active.
    *   The response is parsed for an "on" or "off" state.
    *   This boolean status is exposed as a binary sensor.
    *   Constants for this sensor were added to `const.py`.

**Supporting Changes:**

*   **`const.py`**: Added new constants for API attribute keys, sensor names, and icons for the endstop and bed leveling sensors.
*   **`coordinator.py`**:
    *   Implemented `_fetch_endstop_status()` to handle `~M119` command and parse its output.
    *   Implemented `_fetch_bed_leveling_status()` to handle `~M420 S0` command and parse its output.
    *   Integrated these new fetch methods into the main data update cycle (`_fetch_data`).
    *   Removed temporary M-code test/logging code.
*   **`binary_sensor.py`**:
    *   Added new `FlashforgeBinarySensor` entities for each of the endstop sensors and the bed leveling status sensor.
    *   Ensured the `is_on` property correctly handles attributes stored at the root of the coordinator's data.
*   **`REVIEW_CHANGES.md`**: Updated to document these new sensor features.

**Investigations (No sensors added from these in this commit):**
*   `~M115` (Firmware/Capabilities): Output was logged for review. Assumed for now that it doesn't offer new, easily translatable sensor data beyond what's already available via the HTTP API.
*   Unit tests for the new parsing logic and sensors were noted as a valuable future addition but not implemented in this pass.

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

