### PR TITLE
Refactor sensor entity categories to None

Based on your feedback, this commit changes the `entity_category` for several binary sensors from `DIAGNOSTIC` or `CONFIG` to `None`. This ensures these sensors appear in the main "Sensors" panel of the device in Home Assistant, rather than being grouped under "Diagnostic" or "Configuration" sections.

**Affected Binary Sensors (in `binary_sensor.py`):**
- "Connected" (was DIAGNOSTIC)
- "Error" (was DIAGNOSTIC)
- "Auto Shutdown Enabled" (was CONFIG)
- "External Fan Active" (was DIAGNOSTIC)
- "Internal Fan Active" (was DIAGNOSTIC)
- X Endstop Sensor (was DIAGNOSTIC)
- Y Endstop Sensor (was DIAGNOSTIC)
- Z Endstop Sensor (was DIAGNOSTIC)
- Filament Endstop Sensor (was DIAGNOSTIC)
- Bed Leveling Status Sensor (was DIAGNOSTIC)

**Verification:**
- Sensors in `sensor.py` were verified to already default to `entity_category = None`, which aligns with this change.

**Documentation:**
- `REVIEW_CHANGES.md` has been updated to reflect this modification.

### DIFF
--- a/REVIEW_CHANGES.md
+++ b/REVIEW_CHANGES.md
@@ -14,7 +14,8 @@ This document summarizes the key changes implemented based on a comprehensive co
 
 ### 2. `binary_sensor.py`
 - **Error Handling**: Implemented safer conversion of `printProgress` data by adding a `try-except ValueError` block.
-- **Entity Definitions**: Assigned more specific `device_class` (e.g., `POWER`, `RUNNING`) and `entity_category` (e.g., `CONFIG`, `DIAGNOSTIC`) for newly added binary sensors (Auto Shutdown, Fans).
+- **Entity Definitions**: Assigned more specific `device_class` (e.g., `POWER`, `RUNNING`) for some sensors.
+- **Entity Categorization**: Changed `entity_category` to `None` for several sensors (Connected, Error, Auto Shutdown, Fans, Endstops, Bed Leveling) to make them appear on the main device panel, per user request.
 - **Logging**: Added debug logging for cases where coordinator data is unavailable during state determination.
 - **Maintainability**: Replaced hardcoded API attribute strings with the newly defined constants from `const.py`.
 - **New Sensors Added**: Implemented binary sensors for X, Y, Z endstops, a filament runout sensor, and bed leveling status, based on data fetched by the coordinator.
@@ -30,9 +31,10 @@ This document summarizes the key changes implemented based on a comprehensive co
     - Changed `state_class` for the "nozzleStyle" sensor to `None` (assuming textual data).
 - **Error Handling**: Enhanced error logging for percentage conversion failures, including more context and full exception information.
 - **Maintainability**: Replaced hardcoded API attribute strings (e.g., for firmware version) with constants from `const.py`.
+- **Entity Categorization**: Verified all sensors default to `entity_category = None`, which is appropriate for primary measurement sensors.
 
 ### 5. `coordinator.py`
-- **Refactoring**: Centralized TCP command sending logic by refactoring common operations into a new private helper method (`_send_tcp_command`), reducing code duplication.
+- **Refactoring**: Centralized TCP command sending logic by refactoring common operations into a new private helper method (`_send_tcp_command`), reducing code duplication and ensuring all TCP commands (including `move_axis`) use this helper.
 - **Robustness**:
     - Added detailed comments explaining the expected M661 (file list) response format.
     - Made M661 parsing more defensive with additional checks and improved warning/debug logging for unexpected scenarios.
@@ -85,3 +87,11 @@ This section details new sensors and functionalities added after the initial cod
 - This sensor reports whether bed leveling compensation is currently active on the printer.
 - The state is derived from the output of the `~M420 S0` G-code command (or a similar query).
 - An "on" state means bed leveling is active, and "off" means it is inactive.
+
+## Entity Categorization Update (User Request)
+
+- **Moved Diagnostic and Configuration Sensors to Main Panel**:
+    - Based on user feedback, all binary sensors previously categorized as `DIAGNOSTIC` or `CONFIG` have had their `entity_category` changed to `None`.
+    - This makes these sensors appear in the main "Sensors" panel in Home Assistant, rather than under "Diagnostic" or "Configuration" sections of the device page.
+    - Affected binary sensors include: "Connected", "Error", "Auto Shutdown Enabled", "External Fan Active", "Internal Fan Active", all Endstop sensors (X, Y, Z, Filament), and the "Bed Leveling Active" sensor.
+    - Regular sensors in `sensor.py` were verified to already default to `entity_category = None`.

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -119,7 +119,7 @@ async def async_setup_entry(
             name="Connected",
             icon="mdi:connection",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             connection_status_sensor=True,
         ),
         # Error status
@@ -128,7 +128,7 @@ async def async_setup_entry(
             name="Error",
             icon="mdi:alert-circle",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             error_sensor=True,
         ),
         # Auto Shutdown Enabled
@@ -137,7 +137,7 @@ async def async_setup_entry(
             name="Auto Shutdown Enabled",
             icon="mdi:timer-cog-outline",  # Or mdi:power-settings
             device_class=BinarySensorDeviceClass.POWER,
-            entity_category=EntityCategory.CONFIG,
+            entity_category=None,
             detail_attribute=API_ATTR_AUTO_SHUTDOWN,
             value_on=AUTO_SHUTDOWN_ENABLED_STATE,
         ),
@@ -147,7 +147,7 @@ async def async_setup_entry(
             name="External Fan Active",
             icon="mdi:fan",
             device_class=BinarySensorDeviceClass.RUNNING,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_EXTERNAL_FAN_STATUS,
             value_on=FAN_STATUS_ON_STATE,
         ),
@@ -157,7 +157,7 @@ async def async_setup_entry(
             name="Internal Fan Active",
             icon="mdi:fan-alert",  # Using a different fan icon for variety, or mdi:fan
             device_class=BinarySensorDeviceClass.RUNNING,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_INTERNAL_FAN_STATUS,
             value_on=FAN_STATUS_ON_STATE,
         ),
@@ -167,7 +167,7 @@ async def async_setup_entry(
             name=NAME_X_ENDSTOP,
             icon=ICON_X_ENDSTOP,
             device_class=None,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_X_ENDSTOP_STATUS,
             value_on=True, # Sensor is "on" (problem/triggered) if M119 reports triggered (True)
         ),
@@ -176,7 +176,7 @@ async def async_setup_entry(
             name=NAME_Y_ENDSTOP,
             icon=ICON_Y_ENDSTOP,
             device_class=None,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_Y_ENDSTOP_STATUS,
             value_on=True,
         ),
@@ -185,7 +185,7 @@ async def async_setup_entry(
             name=NAME_Z_ENDSTOP,
             icon=ICON_Z_ENDSTOP,
             device_class=None,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_Z_ENDSTOP_STATUS,
             value_on=True,
         ),
@@ -194,7 +194,7 @@ async def async_setup_entry(
             name=NAME_FILAMENT_ENDSTOP,
             icon=ICON_FILAMENT_ENDSTOP,
             device_class=BinarySensorDeviceClass.TAMPER, # Or None, or MOISTURE if it's a runout sensor
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_FILAMENT_ENDSTOP_STATUS,
             value_on=True, # Assuming 'triggered' means problem (filament out)
         ),
@@ -204,7 +204,7 @@ async def async_setup_entry(
             name=NAME_BED_LEVELING,
             icon=ICON_BED_LEVELING,
             device_class=None,
-            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_category=None,
             detail_attribute=API_ATTR_BED_LEVELING_STATUS,
             value_on=True
         ),


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

