### PR TITLE
Merge pull request #58 from JMcCumberIO/code-review-fixes

Fix: Correct toggle_light field definition in services.yaml

The `toggle_light` service was not showing its `state` field in the UI,
leading to "required key not provided" errors.

This commit meticulously corrects the `toggle_light` service definition
in `services.yaml`. The primary change is ensuring the boolean selector
for the `state` field is formatted as `boolean: {}`, which is a more
robust and precise way to define an empty mapping for the selector.

This change should allow Home Assistant's UI to correctly parse the
service definition and render the necessary input field for the 'state'
parameter, resolving the issue where the field was not appearing and
thus the required data was not being sent.

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -13,8 +13,6 @@ from homeassistant.const import (
     UnitOfInformation,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    SPEED_MILLIMETERS_PER_SECOND,
 )
 from typing import Dict, Any # Import Dict and Any for type hinting
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -197,7 +195,7 @@ SENSOR_DEFINITIONS = {
     # "internalFanStatus": ("Internal Fan Status", None, None, None, False, False), # Replaced by binary_sensor
     "tvoc": (
         "TVOC",
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "µg/m³",
         SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         SensorStateClass.MEASUREMENT,
         False,
@@ -231,7 +229,7 @@ SENSOR_DEFINITIONS = {
     ),
     "currentPrintSpeed": (
         "Current Print Speed",
-        SPEED_MILLIMETERS_PER_SECOND,
+        "mm/s",
         SensorDeviceClass.SPEED,
         SensorStateClass.MEASUREMENT,
         False,

--- a/services.yaml
+++ b/services.yaml
@@ -43,7 +43,7 @@ toggle_light:
       required: true
       example: true
       selector:
-        boolean:
+        boolean: {}
 
 resume_print:
   name: Resume Print


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

