### PR TITLE
Merge pull request #60 from JMcCumberIO/code-review-fixes

Fix: Comprehensive review and correction of services.yaml field definitions

Ensures all service field definitions in `services.yaml` use precise
and robust syntax, particularly for selectors (e.g., `text: {}`,
`boolean: {}`, `number: {mode: box}`).

This was identified as a potential root cause for UI fields not
rendering correctly for some services (like `toggle_light`) and
potentially contributing to "unknown error" messages for other services
if their parameters were not being correctly presented or submitted
by the UI.

This commit standardizes the definitions for all services with parameters
to improve UI compatibility and reliability of service calls.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -43,7 +43,7 @@ toggle_light:
       required: true
       example: true
       selector:
-        boolean:
+        boolean: {}
 
 resume_print:
   name: Resume Print

--- a/services.yaml
+++ b/services.yaml
@@ -21,7 +21,7 @@ start_print:
       required: true
       example: "/PrintFiles/model.gcode"
       selector:
-        text:
+        text: {}
 
 cancel_print:
   name: Cancel Print
@@ -118,25 +118,25 @@ move_axis:
       description: Target X-axis coordinate in mm.
       optional: true
       selector:
-        number: {} # Simplified selector
+        number: {mode: box}
     y:
       name: Y Coordinate
       description: Target Y-axis coordinate in mm.
       optional: true
       selector:
-        number: {} # Simplified selector
+        number: {mode: box}
     z:
       name: Z Coordinate
       description: Target Z-axis coordinate in mm.
       optional: true
       selector:
-        number: {} # Simplified selector
+        number: {mode: box}
     feedrate:
       name: Feedrate
       description: Speed of movement in mm/minute. Printer's default if not specified.
       optional: true
       selector:
-        number: {} # Simplified selector
+        number: {mode: box, unit_of_measurement: "mm/min"}
 
 delete_file:
   name: Delete File
@@ -147,7 +147,7 @@ delete_file:
       description: "The path of the file to delete. Examples: 'test.gcode', '/data/user/test.gcode'."
       required: true
       selector:
-        text:
+        text: {}
 
 disable_steppers:
   name: Disable Stepper Motors
@@ -198,19 +198,19 @@ home_axes:
       description: "Set to true to include X-axis in homing."
       optional: true
       selector:
-        boolean:
+        boolean: {}
     y:
       name: Home Y-axis
       description: "Set to true to include Y-axis in homing."
       optional: true
       selector:
-        boolean:
+        boolean: {}
     z:
       name: Home Z-axis
       description: "Set to true to include Z-axis in homing."
       optional: true
       selector:
-        boolean:
+        boolean: {}
 
 # Existing services (verified)
 filament_change:


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

