### PR TITLE
Feat: Enhance move_axis with sliders and add move_relative service



### DIFF
--- a/const.py
+++ b/const.py
@@ -117,3 +117,8 @@ NAME_BED_LEVELING = "Bed Leveling Active"
 
 # Bed Leveling Sensor Icon
 ICON_BED_LEVELING = "mdi:checkerboard" # Or mdi:format-list-bulleted-type
+
+# Service Name Constants
+# (It's better to import these from __init__.py if they are defined there,
+# but if defined here, ensure they match __init__.py and services.yaml)
+SERVICE_MOVE_RELATIVE = "move_relative"

--- a/services.yaml
+++ b/services.yaml
@@ -118,25 +118,25 @@ move_axis:
       description: Target X-axis coordinate in mm.
       optional: true
       selector:
-        number: {mode: box}
+        number: {mode: slider, min: 0, max: 220, unit_of_measurement: "mm"}
     y:
       name: Y Coordinate
       description: Target Y-axis coordinate in mm.
       optional: true
       selector:
-        number: {mode: box}
+        number: {mode: slider, min: 0, max: 220, unit_of_measurement: "mm"}
     z:
       name: Z Coordinate
       description: Target Z-axis coordinate in mm.
       optional: true
       selector:
-        number: {mode: box}
+        number: {mode: slider, min: 0, max: 220, unit_of_measurement: "mm"}
     feedrate:
       name: Feedrate
       description: Speed of movement in mm/minute. Printer's default if not specified.
       optional: true
       selector:
-        number: {mode: box, unit_of_measurement: "mm/min"}
+        number: {mode: slider, min: 100, max: 6000, unit_of_measurement: "mm/min"}
 
 delete_file:
   name: Delete File
@@ -281,3 +281,44 @@ read_settings_from_eeprom:
   name: Read Settings from EEPROM
   description: "Reads current settings from EEPROM (via M501) and logs them. The full output is logged at DEBUG level, a summary may be logged at INFO level."
   fields: {}
+
+move_relative:
+  name: Move Relative
+  description: "Moves printer axes by a relative amount. Specify at least one axis. Printer returns to absolute G-code mode afterwards."
+  fields:
+    x:
+      name: X Offset
+      description: "Relative move for X-axis (mm). Positive or negative."
+      optional: true
+      example: 10.0
+      selector:
+        number:
+          mode: box
+          # No unit_of_measurement needed for offset, but could add step: 0.1 for UI
+    y:
+      name: Y Offset
+      description: "Relative move for Y-axis (mm). Positive or negative."
+      optional: true
+      example: -5.5
+      selector:
+        number:
+          mode: box
+    z:
+      name: Z Offset
+      description: "Relative move for Z-axis (mm). Positive or negative."
+      optional: true
+      example: 1.0
+      selector:
+        number:
+          mode: box
+    feedrate:
+      name: Feedrate
+      description: "Speed for this relative move (mm/min). Optional. Uses printer default if not set."
+      optional: true
+      example: 1500
+      selector:
+        number:
+          mode: box
+          min: 100 # Consistent with move_axis
+          max: 6000 # Consistent with move_axis
+          unit_of_measurement: "mm/min"


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->This commit introduces enhancements to axis movement services:

1.  **`move_axis` Service UI Update (`services.yaml`):**
    *   Changed the UI selectors for `x`, `y`, `z` fields to sliders with a range of 0-220mm (based on Adventurer 5M Pro dimensions).
    *   Changed the UI selector for the `feedrate` field to a slider with a range of 100-6000 mm/min.
    *   This provides you with a more interactive way to set absolute positions.

2.  **New `move_relative` Service:**
    *   Added a new service `flashforge_adventurer5m.move_relative` for jogging/relative movements.
    *   Takes optional `x`, `y`, `z` (float offsets) and `feedrate` (int) parameters.
    *   Implemented in `coordinator.py` by:
        *   Sending G91 to enable relative mode.
        *   Sending G0 with the specified offsets and feedrate.
        *   Sending G90 to restore absolute mode.
    *   Added `SERVICE_MOVE_RELATIVE` constant to `const.py`.
    *   Defined schema, handler, and registration for this service in `__init__.py`.
    *   Added service definition to `services.yaml` with `number` selectors (mode `box`) for offsets.

These changes offer you more flexible and user-friendly options for controlling printer axis movements from Home Assistant.

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

