### PR TITLE
Fix: Correct SyntaxWarning and NameError in const.py

This commit addresses two critical errors in `const.py`:

1.  Resolves a `SyntaxWarning: invalid escape sequence '\o'` by correcting the string for `M661_CMD_PREFIX`. The erroneous `\o` was changed to `o`, ensuring the intended `\rok\r\n` sequence.
2.  Fixes a `NameError: name 'API_ATTR_DETAIL' is not defined` by reordering the constant definitions. `API_ATTR_DETAIL` is now defined before its use in `REQUIRED_RESPONSE_FIELDS`.

These changes should allow the flashforge_adventurer5m integration to load correctly. The `Detected blocking call to import_module` warning is noted but not addressed by this commit as it was not the cause of the load failure.

### DIFF
--- a/const.py
+++ b/const.py
@@ -46,6 +46,7 @@ API_KEY_MESSAGE = "message" # Response message
 API_VALUE_SUCCESS_CODE = 0 # Expected value of "code" field for successful operations
 
 # Key attributes for API response validation
+API_ATTR_DETAIL = "detail"  # Key for the nested detail object in API response
 REQUIRED_RESPONSE_FIELDS = [API_KEY_CODE, API_KEY_MESSAGE, API_ATTR_DETAIL] # Updated to use constants
 REQUIRED_DETAIL_FIELDS = [
     "status", # API_ATTR_STATUS
@@ -94,7 +95,6 @@ API_ATTR_FIRMWARE_VERSION = "firmwareVersion"
 API_ATTR_IP_ADDR = "ipAddr"
 API_ATTR_CAMERA_STREAM_URL = "cameraStreamUrl"
 API_ATTR_MODEL = "model" # Printer model as reported by API
-API_ATTR_DETAIL = "detail"  # Key for the nested detail object in API response
 
 # API Attribute Keys for Endstop Status (parsed from M119, stored in coordinator.data)
 API_ATTR_X_ENDSTOP_STATUS = "x_endstop_status"
@@ -213,7 +213,7 @@ TCP_CMD_M661_PATH_PREFIX = "/data/" # File paths from M661 start with this
 
 # M661 File List Parsing
 M661_SEPARATOR = "::\x00\x00\x00"
-M661_CMD_PREFIX = "CMD M661 Received.\r\ok\r\n" # Note: original had a typo here, fixed ok
+M661_CMD_PREFIX = "CMD M661 Received.\rok\r\n" # Note: original had a typo here, fixed ok
 M661_FILE_EXT_GCODE = ".gcode"
 M661_FILE_EXT_GX = ".gx"
 


### PR DESCRIPTION
## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

