### PR TITLE
Fix: Resolve ImportError for DEFAULT_TCP_TIMEOUT

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -28,7 +28,7 @@ from .const import (
     DEFAULT_PRINTING_SCAN_INTERVAL,
     CONF_PRINTING_SCAN_INTERVAL,
     CONF_TCP_TIMEOUT, # Added
-    DEFAULT_TCP_TIMEOUT, # Assuming this will be TIMEOUT_COMMAND from const.py
+    DEFAULT_TCP_TIMEOUT,
     DEFAULT_PORT,
     DEFAULT_HOST,
     TIMEOUT_CONNECTION_TEST,
@@ -37,7 +37,7 @@ from .const import (
     ENDPOINT_DETAIL,
     REQUIRED_RESPONSE_FIELDS,
 )
-from .const import TIMEOUT_COMMAND # To use as DEFAULT_TCP_TIMEOUT
+# from .const import TIMEOUT_COMMAND # No longer needed, DEFAULT_TCP_TIMEOUT is used
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class FlashforgeOptionsFlow(config_entries.OptionsFlow):
         )
         current_tcp_timeout = self.config_entry.options.get(
             CONF_TCP_TIMEOUT,
-            TIMEOUT_COMMAND # Use TIMEOUT_COMMAND as default
+            DEFAULT_TCP_TIMEOUT # Use the new default constant
         )
 
         # Build the options schema

--- a/const.py
+++ b/const.py
@@ -17,6 +17,7 @@ CONF_TCP_TIMEOUT = "tcp_timeout"
 # Timeout settings (in seconds)
 TIMEOUT_API_CALL = 10
 TIMEOUT_COMMAND = 5 # This will serve as DEFAULT_TCP_TIMEOUT for the new config option
+DEFAULT_TCP_TIMEOUT = 5 # Default timeout for TCP client operations
 TIMEOUT_CONNECTION_TEST = 5
 
 # Retry settings


### PR DESCRIPTION
The constant `DEFAULT_TCP_TIMEOUT` was being imported in `config_flow.py` but was not defined in `const.py`. This caused an `ImportError` when Home Assistant attempted to load the integration's config flow.

This commit addresses the issue by:
1. Defining `DEFAULT_TCP_TIMEOUT = 5` in `const.py`. The value is based on the existing `TIMEOUT_COMMAND` which comments indicated was intended for this purpose.
2. Updating `config_flow.py` to use this new `DEFAULT_TCP_TIMEOUT` constant for the options flow default, replacing a direct usage of `TIMEOUT_COMMAND`.
3. Removing a redundant import of `TIMEOUT_COMMAND` in `config_flow.py` that was previously intended for this default.

## Description
<!-- Describe the changes you're proposing -->

## Testing
<!-- Describe how you've tested these changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Edge cases covered
- [ ] Error conditions tested

### Test Data
- [ ] Using mock data only (no real printer data)
- [ ] Test data follows security guidelines
- [ ] No sensitive information included

### Local Testing Completed
- [ ] Tested with local development printer
- [ ] All tests pass locally
- [ ] No test files included in commit

### Test Documentation
- [ ] Test cases documented
- [ ] Mock data documented
- [ ] Testing steps documented

## Security
<!-- Confirm security requirements are met -->
- [ ] No real printer credentials included
- [ ] No sensitive data in test files
- [ ] No production printer dependencies

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated
- [ ] Changes tested locally
- [ ] All tests pass
- [ ] No test files committed

## Additional Notes
<!-- Any additional information that might be helpful -->

## Test Environment
<!-- Describe your test environment -->
```python
{
    "home_assistant_version": "2023.XX.X",
    "python_version": "3.XX",
    "development_printer": "Flashforge Adventurer 5M PRO",
    "test_environment": "Local development"
}
```

## Breaking Changes
- [ ] This PR includes breaking changes
- [ ] Tests updated for breaking changes
- [ ] Documentation updated for breaking changes

## Related Issues
<!-- Link any related issues -->

